### PR TITLE
Display first contactInfo details for a contact only in default view

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -113,6 +113,7 @@
                                     <includes>
                                         **/iso19115-3.2018/**/subtemplate-transformation.xsl,
                                         **/iso19115-3.2018/**/index-subtemplate.xsl,
+                                        **/iso19115-3.2018/**/index-fields/common.xsl,
                                         **/iso19115-3.2018/**/suggest.xsl,
                                         **/iso19115-3.2018/schema-ident.xml
                                     </includes>

--- a/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/index-fields/common.xsl
+++ b/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/index-fields/common.xsl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:joda="java:org.fao.geonet.domain.ISODate"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gn-fn-core="http://geonetwork-opensource.org/xsl/functions/core"
+                xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
+                xmlns:gn-fn-iso19115-3.2018="http://geonetwork-opensource.org/xsl/functions/profiles/iso19115-3.2018"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                exclude-result-prefixes="#all">
+
+  <!-- Include core templates -->
+
+  <xsl:import href="common-core.xsl"/>
+
+  <!-- Override core contactIndexing template to fix issues indexing and displaying multiple contact info (address,
+       email, phone) details until core fix is available.  Where multiple different contactInfo elements are recorded
+       for a party - index/show the first only -->
+
+  <xsl:template name="ContactIndexing">
+    <xsl:param name="type" select="'resource'" required="no" as="xs:string"/>
+    <xsl:param name="fieldPrefix" select="'responsibleParty'" required="no" as="xs:string"/>
+    <xsl:param name="lang"/>
+    <xsl:param name="langId"/>
+
+    <!-- Only used in ISO19139 -->
+    <xsl:variable name="position" select="'0'"/>
+
+    <!-- Name is optional if logo or identifier is provided -->
+    <xsl:if test="cit:name">
+      <xsl:copy-of select="gn-fn-iso19115-3.2018:index-field('orgName', cit:name, $langId)"/>
+    </xsl:if>
+
+    <xsl:variable name="uuid" select="@uuid"/>
+    <xsl:variable name="role" select="../../cit:role/*/@codeListValue"/>
+    <xsl:variable name="email" select="cit:contactInfo[1]/cit:CI_Contact/
+                             cit:address/cit:CI_Address/
+                             cit:electronicMailAddress/gco:CharacterString[normalize-space()!='']|
+                 cit:individual//cit:contactInfo[1]/cit:CI_Contact/
+                                cit:address/cit:CI_Address/
+                                cit:electronicMailAddress/gco:CharacterString[normalize-space()!='']"/>
+    <xsl:variable name="roleTranslation" select="util:getCodelistTranslation('cit:CI_RoleCode', string($role), string($lang))"/>
+    <xsl:variable name="logo" select="cit:logo/mcc:MD_BrowseGraphic/mcc:fileName/gco:CharacterString"/>
+    <xsl:variable name="website" select="cit:contactInfo[1]//cit:onlineResource[1]/*/cit:linkage/gco:CharacterString"/>
+    <xsl:variable name="phones"
+                  select="cit:contactInfo[1]/cit:CI_Contact/cit:phone/*/cit:number/gco:CharacterString"/>
+    <!--<xsl:variable name="phones"
+                  select="cit:contactInfo/cit:CI_Contact/cit:phone/concat(*/cit:numberType/*/@codeListValue, ':', */cit:number/gco:CharacterString)"/>-->
+    <xsl:variable name="address" select="string-join(cit:contactInfo[1]/*/cit:address/*/(
+                                          cit:deliveryPoint|cit:postalCode|cit:city|
+                                          cit:administrativeArea|cit:country)/gco:CharacterString/text(), ', ')"/>
+    <xsl:variable name="individualNames" select="cit:individual//cit:name/gco:CharacterString"/>
+    <xsl:variable name="positionName" select="cit:individual//cit:positionName/gco:CharacterString"/>
+
+    <xsl:variable name="orgName">
+      <xsl:apply-templates mode="localised" select="cit:name">
+        <xsl:with-param name="langId" select="concat('#', $langId)"/>
+      </xsl:apply-templates>
+    </xsl:variable>
+
+    <Field name="{$type}_{$fieldPrefix}_{$role}"
+           string="{$orgName}"
+           store="false"
+           index="true"/>
+
+    <Field name="{$fieldPrefix}"
+           string="{concat($roleTranslation, '|',
+                           $type, '|',
+                           $orgName, '|',
+                           $logo, '|',
+                           string-join($email, ','), '|',
+                           string-join($individualNames, ','), '|',
+                           string-join($positionName, ','), '|',
+                           $address, '|',
+                           string-join($phones, ','), '|',
+                           $uuid, '|',
+                           $position, '|',
+                           $website)}"
+           store="true" index="false"/>
+
+    <xsl:for-each select="$email">
+      <Field name="{$fieldPrefix}Email" string="{string(.)}" store="true" index="true"/>
+      <Field name="{$fieldPrefix}RoleAndEmail" string="{$role}|{string(.)}" store="true" index="true"/>
+    </xsl:for-each>
+    <xsl:for-each select="@uuid">
+      <Field name="{$fieldPrefix}Uuid" string="{string(.)}" store="true" index="true"/>
+      <Field name="{$fieldPrefix}RoleAndUuid" string="{$role}|{string(.)}" store="true" index="true"/>
+    </xsl:for-each>
+
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Only display address, email, phone and website details from the first contactInfo element for a contact in the default
view to resolve indexing/default view display issues.  The current contact display handling is designed for 19139 which only allowed one contactInfo for a contact.   CSIRO are using 2 in 19115-3:2018 - the first for the postal address and the second for the street address with all other details duplicated.

For example for https://marlin.csiro.au/geonetwork/srv/eng/catalog.search;jsessionid=nxv1opa2asopuu6g182c3n4f#/metadata/c1229b01-41c7-08bf-e044-00144f7bc0f4

### In Marlin

![image](https://user-images.githubusercontent.com/1860215/91514833-1bf30b80-e92b-11ea-8e53-6cf9799250b0.png)

### In our build with these changes:

![image](https://user-images.githubusercontent.com/1860215/91527698-9468c500-e949-11ea-9e86-00f6e4178bbd.png)

and

![image](https://user-images.githubusercontent.com/1860215/91527642-7bf8aa80-e949-11ea-8924-c792afdafc6e.png)
