### PR TITLE
Addresses aodn/backlog#2298 - add aodn xml view

### DIFF
--- a/main/src/main/webapp/WEB-INF/data/data/formatter/xml_view_aodn/view.groovy
+++ b/main/src/main/webapp/WEB-INF/data/data/formatter/xml_view_aodn/view.groovy
@@ -1,0 +1,14 @@
+import groovy.xml.XmlUtil
+
+handlers.add {true} { el ->
+    def out = new StringWriter()
+    new XmlNodePrinter(new PrintWriter(out)).print(new XmlParser().parseText(XmlUtil.serialize(el)))
+    def xmlString = XmlUtil.escapeXml(out.toString())
+    """
+ <pre>
+  <code class='html'>
+  $xmlString
+  </code>
+ </pre>
+"""
+}


### PR DESCRIPTION
We've been using the packaged xml view for displaying xml when viewing metadata but this isn't
designed for doing this currently.  It loads javascript libraries that have already been loaded resulting in two menu toggle triggers being registered for the display mode button in some situations which results
in clicking the button being handled twice, showing the menu the first time and then hiding the menu.
The core code doesn't actually use those libraries so I'll raise a core issue to remove them so we can remove this custom view
when we upgrade.