### PR TITLE
remove our s3 repo from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
             <url>https://repo.osgeo.org/repository/geotools-releases/</url>
         </repository>
         <repository>
-            <id>aodn</id>
-            <url>https://s3-ap-southeast-2.amazonaws.com/imos-artifacts/repo/maven/</url>
-        </repository>
-        <repository>
             <id>geonetwork</id>
             <url>https://repo.osgeo.org/repository/geonetwork-releases/</url>
         </repository>


### PR DESCRIPTION
@jonescc regarding https://github.com/aodn/backlog/issues/1696 I just tried removing the repo and it built okay in Jenkins. 

Previously I had thought that _something_ was still needing to pull some packages from s3 but maybe that was while my dependencies were still a bit screwed up.

If you can merge, then I'll deploy to catalogue.dev and confirm it as okay. This branch builds okay in jenkins: https://build.aodn.org.au/job/geonetwork-build_build/job/test-removal-s3-repo/1/console