### PR TITLE
mcp to 19115-3 can use a configuration file for url substitutions

### DIFF
--- a/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/dev.xml
+++ b/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/dev.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- URL Substitutions to be performed when migrating records from GN2 to GN3 -->
+
+<config>
+    <url>https://catalogue.dev.aodn.org.au:443/geonetwork/srv</url>
+
+    <!-- Instance keyword thesauri links -->
+    <substitution match="https?://catalogue.dev.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
+            replaceWith="https://catalogue.dev.aodn.org.au:443/geonetwork/srv/eng/thesaurus"/>
+
+    <!-- Instance point of truth links -->
+    <substitution match="https?://catalogue.dev.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
+            replaceWith="https://catalogue.dev.aodn.org.au:443/geonetwork/srv/api/records/"/>
+
+    <!-- Instance download links -->
+    <substitution match="https?://catalogue.dev.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
+            replaceWith="https://catalogue.dev.aodn.org.au:433/geonetwork/srv/api/records/$2/attachments/$3"/>
+</config>

--- a/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/prod.xml
+++ b/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/prod.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-imos -->
-<!-- instance to the new GN3 production catalogue-imos instance -->
+<!-- URL Substitutions to be performed when migrating records from GN2 to GN3 -->
 
 <config>
     <url>https://catalogue-imos.aodn.org.au:443/geonetwork/srv</url>

--- a/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/rc.xml
+++ b/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/rc.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- URL Substitutions to be performed when migrating records from the old GN2 catalogue-rc -->
-<!-- instance to the GN3 catalogue-rc test instance -->
+<!-- URL Substitutions to be performed when migrating records from GN2 to GN3 -->
 
 <config>
     <url>https://catalogue-rc.aodn.org.au:443/geonetwork/srv</url>

--- a/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/fromMCP.xsl
+++ b/main/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/fromMCP.xsl
@@ -8,7 +8,17 @@
     <xsl:import href="postprocess.xsl"/>
     
     <xsl:param name="dataParamsConfig" select="'../config/mcpdataparameters_config.xml'"/>
-    <xsl:param name="urlSubstitutionsConfig" select="'../config/url-substitutions/prod.xml'"/>
+
+    <xsl:param name="urlSubstitutionsConfig">
+        <xsl:choose>
+            <xsl:when test="system-property('catalogue.urlsubstitutions.file')">
+                <xsl:value-of select="system-property('catalogue.urlsubstitutions.file')" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="'../config/url-substitutions/prod.xml'" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:param>
 
     <xsl:template match="/">
         <xsl:variable name="convertedMetadata">

--- a/main/src/main/webapp/xsl/conversion/import/MCP-to-ISO19115-3-2018.xsl
+++ b/main/src/main/webapp/xsl/conversion/import/MCP-to-ISO19115-3-2018.xsl
@@ -4,6 +4,5 @@
     <xsl:import href="../../../WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/fromMCP.xsl"/>
 
     <xsl:param name="dataParamsConfig" select="'../config/mcpdataparameters_config.xml'"/>
-    <xsl:param name="urlSubstitutionsConfig" select="'../config/url-substitutions/prod.xml'"/>
 
 </xsl:stylesheet>


### PR DESCRIPTION
This allows for a url substitutions file to be passed as a jvm system property:  
-Dcatalogue.urlsubstitutions.file="path/to/file/filename.xml"

Example file content:

```
<?xml version="1.0" encoding="UTF-8"?>

<!-- URL Substitutions to be performed when migrating records from the old GN2 -->
<!-- instance to the new GN3 instance -->

<config>
    <url>https://catalogue-imos.aodn.org.au:443/geonetwork/srv</url>

    <!-- Instance keyword thesauri links - map old links used to a consistent GN3 link -->
    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/thesaurus"
            replaceWith="https://imas.Instance-keyword-thesauri-links.au:443/geonetwork/srv/eng/thesaurus"/>

    <!-- Instance point of truth links - map the GN2 endpoint to the GN3 endpoint -->
    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
            replaceWith="https://imas.Instance-point-of-truth-links.au/geonetwork/srv/api/records/"/>

    <!-- References to old url - map references to the old geonetwork endpoint to the GN3 endpoint  -->
    <substitution match="https?://catalogue-123.aodn.org.au(:443)?/geonetwork/srv/eng?/metadata.show\?uuid="
            replaceWith="https://imas.References-to-old-url.au:443/geonetwork/srv/api/records/"/>

    <!-- Instance download links  - map the GN2 endpoint to the GN3 enpoint -->
    <substitution match="https?://catalogue-imos.aodn.org.au(:443)?/geonetwork/srv/eng?/file.disclaimer\?uuid=(.*)&amp;fname=(.*)&amp;access=private"
            replaceWith="https://imas.Instance-download-links.au:443/geonetwork/srv/api/records/$2/attachments/$3"/>
</config>
```

If no file is provided it will default to using ```webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/ISO19139.MCP/config/url-substitutions/prod.xml```