### PR TITLE
3708 set ubuntu20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 ARG BUILDER_UID=9999
+ARG DEBIAN_FRONTEND=noninteractive
 
+ENV TZ=Australia/Hobart
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 ENV HOME /home/builder
 ENV JAVA_TOOL_OPTIONS -Duser.home=/home/builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV JAVA_TOOL_OPTIONS -Duser.home=/home/builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git-core \
     libxml2-utils \
-    libnetcdf11 \
-    libgsl2 \
+    libnetcdf15 \
+    libgsl23 \
     libudunits2-0 \
     openjdk-8-jdk \
     python3-dev \


### PR DESCRIPTION
Upgrade to libnetcdf15 and libgsl23 required

Artifacts: https://build.aodn.org.au/job/geonetwork-build_build/job/3708-set-ubuntu20/2/
Endpoint: http://geonetwork3-cmrose1.dev.aodn.org.au/
geonetwork3:
  endpoint: geonetwork3-cmrose1.dev.aodn.org.au
  password: Geonetwork_admin1!
  stack_integration:
    geonetwork_endpoint: http://geonetwork3-cmrose1.dev.aodn.org.au/geonetwork
    geonetwork_password: Geonetwork_admin1!
    geonetwork_user: geonetwork_admin
  username: geonetwork_admin

